### PR TITLE
Decode `uHHHH` and `'HH` correctly, also with code pages;

### DIFF
--- a/StripRichTextFormat.go
+++ b/StripRichTextFormat.go
@@ -1,54 +1,307 @@
 package rtf
 
 import (
+	"golang.org/x/text/encoding/charmap"
 	"regexp"
 	"strconv"
 	"strings"
-
-	"github.com/golang-collections/collections/stack"
 )
 
-var destinations = []string{
-	"aftncn", "aftnsep", "aftnsepc", "annotation", "atnauthor", "atndate", "atnicn", "atnid",
-	"atnparent", "atnref", "atntime", "atrfend", "atrfstart", "author", "background",
-	"bkmkend", "bkmkstart", "blipuid", "buptim", "category", "colorschememapping",
-	"colortbl", "comment", "company", "creatim", "datafield", "datastore", "defchp", "defpap",
-	"do", "doccomm", "docvar", "dptxbxtext", "ebcend", "ebcstart", "factoidname", "falt",
-	"fchars", "ffdeftext", "ffentrymcr", "ffexitmcr", "ffformat", "ffhelptext", "ffl",
-	"ffname", "ffstattext", "field", "file", "filetbl", "fldinst", "fldrslt", "fldtype",
-	"fname", "fontemb", "fontfile", "fonttbl", "footer", "footerf", "footerl", "footerr",
-	"footnote", "formfield", "ftncn", "ftnsep", "ftnsepc", "g", "generator", "gridtbl",
-	"header", "headerf", "headerl", "headerr", "hl", "hlfr", "hlinkbase", "hlloc", "hlsrc",
-	"hsv", "htmltag", "info", "keycode", "keywords", "latentstyles", "lchars", "levelnumbers",
-	"leveltext", "lfolevel", "linkval", "list", "listlevel", "listname", "listoverride",
-	"listoverridetable", "listpicture", "liststylename", "listtable", "listtext",
-	"lsdlockedexcept", "macc", "maccPr", "mailmerge", "maln", "malnScr", "manager", "margPr",
-	"mbar", "mbarPr", "mbaseJc", "mbegChr", "mborderBox", "mborderBoxPr", "mbox", "mboxPr",
-	"mchr", "mcount", "mctrlPr", "md", "mdeg", "mdegHide", "mden", "mdiff", "mdPr", "me",
-	"mendChr", "meqArr", "meqArrPr", "mf", "mfName", "mfPr", "mfunc", "mfuncPr", "mgroupChr",
-	"mgroupChrPr", "mgrow", "mhideBot", "mhideLeft", "mhideRight", "mhideTop", "mhtmltag",
-	"mlim", "mlimloc", "mlimlow", "mlimlowPr", "mlimupp", "mlimuppPr", "mm", "mmaddfieldname",
-	"mmath", "mmathPict", "mmathPr", "mmaxdist", "mmc", "mmcJc", "mmconnectstr",
-	"mmconnectstrdata", "mmcPr", "mmcs", "mmdatasource", "mmheadersource", "mmmailsubject",
-	"mmodso", "mmodsofilter", "mmodsofldmpdata", "mmodsomappedname", "mmodsoname",
-	"mmodsorecipdata", "mmodsosort", "mmodsosrc", "mmodsotable", "mmodsoudl",
-	"mmodsoudldata", "mmodsouniquetag", "mmPr", "mmquery", "mmr", "mnary", "mnaryPr",
-	"mnoBreak", "mnum", "mobjDist", "moMath", "moMathPara", "moMathParaPr", "mopEmu",
-	"mphant", "mphantPr", "mplcHide", "mpos", "mr", "mrad", "mradPr", "mrPr", "msepChr",
-	"mshow", "mshp", "msPre", "msPrePr", "msSub", "msSubPr", "msSubSup", "msSubSupPr", "msSup",
-	"msSupPr", "mstrikeBLTR", "mstrikeH", "mstrikeTLBR", "mstrikeV", "msub", "msubHide",
-	"msup", "msupHide", "mtransp", "mtype", "mvertJc", "mvfmf", "mvfml", "mvtof", "mvtol",
-	"mzeroAsc", "mzeroDesc", "mzeroWid", "nesttableprops", "nextfile", "nonesttables",
-	"objalias", "objclass", "objdata", "object", "objname", "objsect", "objtime", "oldcprops",
-	"oldpprops", "oldsprops", "oldtprops", "oleclsid", "operator", "panose", "password",
-	"passwordhash", "pgp", "pgptbl", "picprop", "pict", "pn", "pnseclvl", "pntext", "pntxta",
-	"pntxtb", "printim", "private", "propname", "protend", "protstart", "protusertbl", "pxe",
-	"result", "revtbl", "revtim", "rsidtbl", "rxe", "shp", "shpgrp", "shpinst",
-	"shppict", "shprslt", "shptxt", "sn", "sp", "staticval", "stylesheet", "subject", "sv",
-	"svb", "tc", "template", "themedata", "title", "txe", "ud", "upr", "userprops",
-	"wgrffmtfilter", "windowcaption", "writereservation", "writereservhash", "xe", "xform",
-	"xmlattrname", "xmlattrvalue", "xmlclose", "xmlname", "xmlnstbl",
-	"xmlopen",
+var destinations = map[string]bool{
+	"aftncn":             true,
+	"aftnsep":            true,
+	"aftnsepc":           true,
+	"annotation":         true,
+	"atnauthor":          true,
+	"atndate":            true,
+	"atnicn":             true,
+	"atnid":              true,
+	"atnparent":          true,
+	"atnref":             true,
+	"atntime":            true,
+	"atrfend":            true,
+	"atrfstart":          true,
+	"author":             true,
+	"background":         true,
+	"bkmkend":            true,
+	"bkmkstart":          true,
+	"blipuid":            true,
+	"buptim":             true,
+	"category":           true,
+	"colorschememapping": true,
+	"colortbl":           true,
+	"comment":            true,
+	"company":            true,
+	"creatim":            true,
+	"datafield":          true,
+	"datastore":          true,
+	"defchp":             true,
+	"defpap":             true,
+	"do":                 true,
+	"doccomm":            true,
+	"docvar":             true,
+	"dptxbxtext":         true,
+	"ebcend":             true,
+	"ebcstart":           true,
+	"factoidname":        true,
+	"falt":               true,
+	"fchars":             true,
+	"ffdeftext":          true,
+	"ffentrymcr":         true,
+	"ffexitmcr":          true,
+	"ffformat":           true,
+	"ffhelptext":         true,
+	"ffl":                true,
+	"ffname":             true,
+	"ffstattext":         true,
+	"field":              true,
+	"file":               true,
+	"filetbl":            true,
+	"fldinst":            true,
+	"fldrslt":            true,
+	"fldtype":            true,
+	"fname":              true,
+	"fontemb":            true,
+	"fontfile":           true,
+	"fonttbl":            true,
+	"footer":             true,
+	"footerf":            true,
+	"footerl":            true,
+	"footerr":            true,
+	"footnote":           true,
+	"formfield":          true,
+	"ftncn":              true,
+	"ftnsep":             true,
+	"ftnsepc":            true,
+	"g":                  true,
+	"generator":          true,
+	"gridtbl":            true,
+	"header":             true,
+	"headerf":            true,
+	"headerl":            true,
+	"headerr":            true,
+	"hl":                 true,
+	"hlfr":               true,
+	"hlinkbase":          true,
+	"hlloc":              true,
+	"hlsrc":              true,
+	"hsv":                true,
+	"htmltag":            true,
+	"info":               true,
+	"keycode":            true,
+	"keywords":           true,
+	"latentstyles":       true,
+	"lchars":             true,
+	"levelnumbers":       true,
+	"leveltext":          true,
+	"lfolevel":           true,
+	"linkval":            true,
+	"list":               true,
+	"listlevel":          true,
+	"listname":           true,
+	"listoverride":       true,
+	"listoverridetable":  true,
+	"listpicture":        true,
+	"liststylename":      true,
+	"listtable":          true,
+	"listtext":           true,
+	"lsdlockedexcept":    true,
+	"macc":               true,
+	"maccPr":             true,
+	"mailmerge":          true,
+	"maln":               true,
+	"malnScr":            true,
+	"manager":            true,
+	"margPr":             true,
+	"mbar":               true,
+	"mbarPr":             true,
+	"mbaseJc":            true,
+	"mbegChr":            true,
+	"mborderBox":         true,
+	"mborderBoxPr":       true,
+	"mbox":               true,
+	"mboxPr":             true,
+	"mchr":               true,
+	"mcount":             true,
+	"mctrlPr":            true,
+	"md":                 true,
+	"mdeg":               true,
+	"mdegHide":           true,
+	"mden":               true,
+	"mdiff":              true,
+	"mdPr":               true,
+	"me":                 true,
+	"mendChr":            true,
+	"meqArr":             true,
+	"meqArrPr":           true,
+	"mf":                 true,
+	"mfName":             true,
+	"mfPr":               true,
+	"mfunc":              true,
+	"mfuncPr":            true,
+	"mgroupChr":          true,
+	"mgroupChrPr":        true,
+	"mgrow":              true,
+	"mhideBot":           true,
+	"mhideLeft":          true,
+	"mhideRight":         true,
+	"mhideTop":           true,
+	"mhtmltag":           true,
+	"mlim":               true,
+	"mlimloc":            true,
+	"mlimlow":            true,
+	"mlimlowPr":          true,
+	"mlimupp":            true,
+	"mlimuppPr":          true,
+	"mm":                 true,
+	"mmaddfieldname":     true,
+	"mmath":              true,
+	"mmathPict":          true,
+	"mmathPr":            true,
+	"mmaxdist":           true,
+	"mmc":                true,
+	"mmcJc":              true,
+	"mmconnectstr":       true,
+	"mmconnectstrdata":   true,
+	"mmcPr":              true,
+	"mmcs":               true,
+	"mmdatasource":       true,
+	"mmheadersource":     true,
+	"mmmailsubject":      true,
+	"mmodso":             true,
+	"mmodsofilter":       true,
+	"mmodsofldmpdata":    true,
+	"mmodsomappedname":   true,
+	"mmodsoname":         true,
+	"mmodsorecipdata":    true,
+	"mmodsosort":         true,
+	"mmodsosrc":          true,
+	"mmodsotable":        true,
+	"mmodsoudl":          true,
+	"mmodsoudldata":      true,
+	"mmodsouniquetag":    true,
+	"mmPr":               true,
+	"mmquery":            true,
+	"mmr":                true,
+	"mnary":              true,
+	"mnaryPr":            true,
+	"mnoBreak":           true,
+	"mnum":               true,
+	"mobjDist":           true,
+	"moMath":             true,
+	"moMathPara":         true,
+	"moMathParaPr":       true,
+	"mopEmu":             true,
+	"mphant":             true,
+	"mphantPr":           true,
+	"mplcHide":           true,
+	"mpos":               true,
+	"mr":                 true,
+	"mrad":               true,
+	"mradPr":             true,
+	"mrPr":               true,
+	"msepChr":            true,
+	"mshow":              true,
+	"mshp":               true,
+	"msPre":              true,
+	"msPrePr":            true,
+	"msSub":              true,
+	"msSubPr":            true,
+	"msSubSup":           true,
+	"msSubSupPr":         true,
+	"msSup":              true,
+	"msSupPr":            true,
+	"mstrikeBLTR":        true,
+	"mstrikeH":           true,
+	"mstrikeTLBR":        true,
+	"mstrikeV":           true,
+	"msub":               true,
+	"msubHide":           true,
+	"msup":               true,
+	"msupHide":           true,
+	"mtransp":            true,
+	"mtype":              true,
+	"mvertJc":            true,
+	"mvfmf":              true,
+	"mvfml":              true,
+	"mvtof":              true,
+	"mvtol":              true,
+	"mzeroAsc":           true,
+	"mzeroDesc":          true,
+	"mzeroWid":           true,
+	"nesttableprops":     true,
+	"nextfile":           true,
+	"nonesttables":       true,
+	"objalias":           true,
+	"objclass":           true,
+	"objdata":            true,
+	"object":             true,
+	"objname":            true,
+	"objsect":            true,
+	"objtime":            true,
+	"oldcprops":          true,
+	"oldpprops":          true,
+	"oldsprops":          true,
+	"oldtprops":          true,
+	"oleclsid":           true,
+	"operator":           true,
+	"panose":             true,
+	"password":           true,
+	"passwordhash":       true,
+	"pgp":                true,
+	"pgptbl":             true,
+	"picprop":            true,
+	"pict":               true,
+	"pn":                 true,
+	"pnseclvl":           true,
+	"pntext":             true,
+	"pntxta":             true,
+	"pntxtb":             true,
+	"printim":            true,
+	"private":            true,
+	"propname":           true,
+	"protend":            true,
+	"protstart":          true,
+	"protusertbl":        true,
+	"pxe":                true,
+	"result":             true,
+	"revtbl":             true,
+	"revtim":             true,
+	"rsidtbl":            true,
+	"rxe":                true,
+	"shp":                true,
+	"shpgrp":             true,
+	"shpinst":            true,
+	"shppict":            true,
+	"shprslt":            true,
+	"shptxt":             true,
+	"sn":                 true,
+	"sp":                 true,
+	"staticval":          true,
+	"stylesheet":         true,
+	"subject":            true,
+	"sv":                 true,
+	"svb":                true,
+	"tc":                 true,
+	"template":           true,
+	"themedata":          true,
+	"title":              true,
+	"txe":                true,
+	"ud":                 true,
+	"upr":                true,
+	"userprops":          true,
+	"wgrffmtfilter":      true,
+	"windowcaption":      true,
+	"writereservation":   true,
+	"writereservhash":    true,
+	"xe":                 true,
+	"xform":              true,
+	"xmlattrname":        true,
+	"xmlattrvalue":       true,
+	"xmlclose":           true,
+	"xmlname":            true,
+	"xmlnstbl":           true,
+	"xmlopen":            true,
 }
 
 var specialCharacters = map[string]string{
@@ -69,41 +322,64 @@ var specialCharacters = map[string]string{
 	"rdblquote": "\u201D",
 }
 
-var rtfRegex, _ = regexp.Compile("(?i)" + `\\([a-z]{1,32})(-?\d{1,10})?[ ]?|\\'([0-9a-f]{2})|\\([^a-z])|([{}])|[\r\n]+|(.)`)
+var charmaps = map[string]*charmap.Charmap{
+	"437": charmap.CodePage437,
+	//	"708":  nil,
+	//	"709":  nil,
+	//	"710":  nil,
+	//	"711":  nil,
+	//	"720":  nil,
+	//	"819":  nil,
+	"850": charmap.CodePage850,
+	"852": charmap.CodePage852,
+	"860": charmap.CodePage860,
+	"862": charmap.CodePage862,
+	"863": charmap.CodePage863,
+	//	"864":  nil,
+	"865": charmap.CodePage865,
+	"866": charmap.CodePage866,
+	//	"874":  nil,
+	//	"932":  nil,
+	//	"936":  nil,
+	//	"949":  nil,
+	//	"950":  nil,
+	"1250": charmap.Windows1250,
+	"1251": charmap.Windows1251,
+	"1252": charmap.Windows1252,
+	"1253": charmap.Windows1253,
+	"1254": charmap.Windows1254,
+	"1255": charmap.Windows1255,
+	"1256": charmap.Windows1256,
+	"1257": charmap.Windows1257,
+	"1258": charmap.Windows1258,
+	//	"1361": nil,
+}
+
+var rtfRegex = regexp.MustCompile(
+	"(?i)" +
+		`\\([a-z]{1,32})(-?\d{1,10})?[ ]?` +
+		`|\\'([0-9a-f]{2})` +
+		`|\\([^a-z])` +
+		`|([{}])` +
+		`|[\r\n]+` +
+		`|(.)`)
 
 type stackEntry struct {
 	NumberOfCharactersToSkip int
 	Ignorable                bool
 }
 
-func newStackEntry(
-	numberOfCharactersToSkip int,
-	ignorable bool,
-) stackEntry {
+func newStackEntry(numberOfCharactersToSkip int, ignorable bool) stackEntry {
 	return stackEntry{
 		NumberOfCharactersToSkip: numberOfCharactersToSkip,
 		Ignorable:                ignorable,
 	}
 }
 
-func isDestination(word string) bool {
-	for _, destination := range destinations {
-		if destination == word {
-			return true
-		}
-	}
-	return false
-}
-
 // Removes rtf characters from string and returns the new string.
-func StripRichTextFormat(
-	inputRtf string,
-) string {
-	if inputRtf == "" {
-		return ""
-	}
-
-	var stack stack.Stack
+func StripRichTextFormat(inputRtf string) string {
+	var charMap *charmap.Charmap = nil
+	var stack []stackEntry
 	var ignorable bool
 	ucskip := 1
 	curskip := 0
@@ -127,9 +403,12 @@ func StripRichTextFormat(
 		if brace != "" {
 			curskip = 0
 			if brace == "{" {
-				stack.Push(newStackEntry(ucskip, ignorable))
+				stack = append(
+					stack, newStackEntry(ucskip, ignorable))
 			} else if brace == "}" {
-				entry := stack.Pop().(stackEntry)
+				l := len(stack)
+				entry := stack[l-1]
+				stack = stack[:l-1]
 				ucskip = entry.NumberOfCharactersToSkip
 				ignorable = entry.Ignorable
 			}
@@ -148,11 +427,13 @@ func StripRichTextFormat(
 			}
 		} else if word != "" {
 			curskip = 0
-			if isDestination(word) {
+			if destinations[word] {
 				ignorable = true
 			} else if ignorable {
 			} else if specialCharacters[word] != "" {
 				returnString += specialCharacters[word]
+			} else if word == "ansicpg" {
+				charMap = charmaps[arg]
 			} else if word == "uc" {
 				i, _ := strconv.Atoi(arg)
 				ucskip = i
@@ -161,7 +442,7 @@ func StripRichTextFormat(
 				if c < 0 {
 					c += 0x10000
 				}
-				returnString += strconv.Itoa(c)
+				returnString += string(rune(c))
 				curskip = ucskip
 			}
 		} else if hex != "" {
@@ -169,16 +450,20 @@ func StripRichTextFormat(
 				curskip -= 1
 			} else if !ignorable {
 				c, _ := strconv.ParseInt(hex, 16, 0)
-				returnString += strconv.Itoa(int(c))
+				if charMap == nil {
+					returnString += string(rune(c))
+				} else {
+					returnString += string(
+						charMap.DecodeByte(byte(c)))
+				}
 			}
 		} else if tchar != "" {
 			if curskip > 0 {
 				curskip -= 1
-			} else if ignorable == false {
+			} else if !ignorable {
 				returnString += tchar
 			}
 		}
 	}
-
 	return returnString
 }


### PR DESCRIPTION
remove a third-party dependency on `stack`;
replace linear search in `destinations` with hash table lookup.